### PR TITLE
.editorconfigの追加#15

### DIFF
--- a/TopologyCardRegister/.editorconfig
+++ b/TopologyCardRegister/.editorconfig
@@ -1,0 +1,450 @@
+# Version: 4.1.1 (Using https://semver.org/)
+# Updated: 2022-05-23
+# See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
+# See https://github.com/RehanSaeed/EditorConfig for updates to this file.
+# See http://EditorConfig.org for more information about .editorconfig files.
+
+##########################################
+# Common Settings
+##########################################
+
+# This file is the top-most EditorConfig file
+root = true
+
+# All Files
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+##########################################
+# File Extension Settings
+##########################################
+
+# Visual Studio Solution Files
+[*.sln]
+indent_style = tab
+
+# Visual Studio XML Project Files
+[*.{csproj,vbproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML Configuration Files
+[*.{xml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON Files
+[*.{json,json5,webmanifest}]
+indent_size = 2
+
+# YAML Files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown Files
+[*.{md,mdx}]
+trim_trailing_whitespace = false
+
+# Web Files
+[*.{htm,html,js,jsm,ts,tsx,cjs,cts,ctsx,mjs,mts,mtsx,css,sass,scss,less,pcss,svg,vue}]
+indent_size = 2
+
+# Batch Files
+[*.{cmd,bat}]
+end_of_line = crlf
+
+# Bash Files
+[*.sh]
+end_of_line = lf
+
+# Makefiles
+[Makefile]
+indent_style = tab
+
+##########################################
+# Default .NET Code Style Severities
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#scope
+##########################################
+
+[*.{cs,csx,cake,vb,vbx}]
+# Default Severity for all .NET Code Style rules below
+dotnet_analyzer_diagnostic.severity = warning
+
+##########################################
+# Language Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
+##########################################
+
+# .NET Style Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
+[*.{cs,csx,cake,vb,vbx}]
+# "this." and "Me." qualifiers
+dotnet_style_qualification_for_field = true:warning
+dotnet_style_qualification_for_property = true:warning
+dotnet_style_qualification_for_method = true:warning
+dotnet_style_qualification_for_event = true:warning
+# Language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = always:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:warning
+dotnet_style_readonly_field = true:warning
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
+# Expression-level preferences
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:warning
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = false:suggestion
+dotnet_diagnostic.IDE0045.severity = suggestion
+dotnet_style_prefer_conditional_expression_over_return = false:suggestion
+dotnet_diagnostic.IDE0046.severity = suggestion
+dotnet_style_prefer_compound_assignment = true:warning
+dotnet_style_prefer_simplified_interpolation = true:warning
+dotnet_style_prefer_simplified_boolean_expressions = true:warning
+# Null-checking preferences
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+# File header preferences
+# file_header_template = <copyright file="{fileName}" company="PROJECT-AUTHOR">\n© PROJECT-AUTHOR\n</copyright>
+# If you use StyleCop, you'll need to disable SA1636: File header copyright text should match.
+# dotnet_diagnostic.SA1636.severity = none
+# Undocumented
+dotnet_style_operator_placement_when_wrapping = end_of_line:warning
+csharp_style_prefer_null_check_over_type_check = true:warning
+
+# C# Style Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules
+[*.{cs,csx,cake}]
+# 'var' preferences
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:warning
+csharp_style_expression_bodied_constructors = true:warning
+csharp_style_expression_bodied_operators = true:warning
+csharp_style_expression_bodied_properties = true:warning
+csharp_style_expression_bodied_indexers = true:warning
+csharp_style_expression_bodied_accessors = true:warning
+csharp_style_expression_bodied_lambdas = true:warning
+csharp_style_expression_bodied_local_functions = true:warning
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_prefer_switch_expression = true:warning
+csharp_style_prefer_pattern_matching = true:warning
+csharp_style_prefer_not_pattern = true:warning
+# Expression-level preferences
+csharp_style_inlined_variable_declaration = true:warning
+csharp_prefer_simple_default_expression = true:warning
+csharp_style_pattern_local_over_anonymous_function = true:warning
+csharp_style_deconstructed_variable_declaration = true:warning
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+# "Null" checking preferences
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+# Code block preferences
+csharp_prefer_braces = true:warning
+csharp_prefer_simple_using_statement = true:suggestion
+dotnet_diagnostic.IDE0063.severity = suggestion
+# 'using' directive preferences
+csharp_using_directive_placement = inside_namespace:warning
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+
+##########################################
+# Unnecessary Code Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/unnecessary-code-rules
+##########################################
+
+# .NET Unnecessary code rules
+[*.{cs,csx,cake,vb,vbx}]
+dotnet_code_quality_unused_parameters = all:warning
+dotnet_remove_unnecessary_suppression_exclusions = none:warning
+
+# C# Unnecessary code rules
+[*.{cs,csx,cake}]
+csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+dotnet_diagnostic.IDE0058.severity = suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+dotnet_diagnostic.IDE0059.severity = suggestion
+
+##########################################
+# Formatting Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules
+##########################################
+
+# .NET formatting rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#net-formatting-rules
+[*.{cs,csx,cake,vb,vbx}]
+# Organize using directives
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+# Dotnet namespace options
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_diagnostic.IDE0130.severity = suggestion
+
+# C# formatting rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#c-formatting-rules
+[*.{cs,csx,cake}]
+# Newline options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#new-line-options
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#indentation-options
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = no_change
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+# Spacing options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#spacing-options
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+# Wrap options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#wrap-options
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+# Namespace options
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#namespace-options
+csharp_style_namespace_declarations = file_scoped:warning
+
+##########################################
+# .NET Naming Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/naming-rules
+##########################################
+
+[*.{cs,csx,cake,vb,vbx}]
+
+##########################################
+# Styles
+##########################################
+
+# camel_case_style - Define the camelCase style
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+# pascal_case_style - Define the PascalCase style
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+# first_upper_style - The first character must start with an upper-case character
+dotnet_naming_style.first_upper_style.capitalization = first_word_upper
+# prefix_interface_with_i_style - Interfaces must be PascalCase and the first character of an interface must be an 'I'
+dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
+# prefix_type_parameters_with_t_style - Generic Type Parameters must be PascalCase and the first character must be a 'T'
+dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
+dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
+# disallowed_style - Anything that has this style applied is marked as disallowed
+dotnet_naming_style.disallowed_style.capitalization  = pascal_case
+dotnet_naming_style.disallowed_style.required_prefix = ____RULE_VIOLATION____
+dotnet_naming_style.disallowed_style.required_suffix = ____RULE_VIOLATION____
+# internal_error_style - This style should never occur... if it does, it indicates a bug in file or in the parser using the file
+dotnet_naming_style.internal_error_style.capitalization  = pascal_case
+dotnet_naming_style.internal_error_style.required_prefix = ____INTERNAL_ERROR____
+dotnet_naming_style.internal_error_style.required_suffix = ____INTERNAL_ERROR____
+
+##########################################
+# .NET Design Guideline Field Naming Rules
+# Naming rules for fields follow the .NET Framework design guidelines
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/index
+##########################################
+
+# All public/protected/protected_internal constant fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.symbols    = public_protected_constant_fields_group
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity   = warning
+
+# All public/protected/protected_internal static readonly fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.symbols    = public_protected_static_readonly_fields_group
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+
+# No other public/protected/protected_internal fields are allowed
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_kinds           = field
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.symbols             = other_public_protected_fields_group
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style               = disallowed_style
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity            = error
+
+##########################################
+# StyleCop Field Naming Rules
+# Naming rules for fields follow the StyleCop analyzers
+# This does not override any rules using disallowed_style above
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers
+##########################################
+
+# All constant fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.symbols    = stylecop_constant_fields_group
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity   = warning
+
+# All static readonly fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.symbols    = stylecop_static_readonly_fields_group
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+
+# No non-private instance fields are allowed
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols               = stylecop_fields_must_be_private_group
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style                 = disallowed_style
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity              = error
+
+# Private fields must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_accessibilities = private
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.symbols     = stylecop_private_fields_group
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity    = warning
+
+# Local variables must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds           = local
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols     = stylecop_local_fields_group
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity    = silent
+
+# This rule should never fire.  However, it's included for at least two purposes:
+# First, it helps to understand, reason about, and root-case certain types of issues, such as bugs in .editorconfig parsers.
+# Second, it helps to raise immediate awareness if a new field type is added (as occurred recently in C#).
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_accessibilities = *
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_kinds           = field
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols  = sanity_check_uncovered_field_case_group
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style    = internal_error_style
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
+
+
+##########################################
+# Other Naming Rules
+##########################################
+
+# All of the following must be PascalCase:
+# - Namespaces
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-namespaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Classes and Enumerations
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Delegates
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#names-of-common-types
+# - Constructors, Properties, Events, Methods
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-type-members
+dotnet_naming_symbols.element_group.applicable_kinds = namespace, class, enum, struct, delegate, event, method, property
+dotnet_naming_rule.element_rule.symbols              = element_group
+dotnet_naming_rule.element_rule.style                = pascal_case_style
+dotnet_naming_rule.element_rule.severity             = warning
+
+# Interfaces use PascalCase and are prefixed with uppercase 'I'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.interface_group.applicable_kinds = interface
+dotnet_naming_rule.interface_rule.symbols              = interface_group
+dotnet_naming_rule.interface_rule.style                = prefix_interface_with_i_style
+dotnet_naming_rule.interface_rule.severity             = warning
+
+# Generics Type Parameters use PascalCase and are prefixed with uppercase 'T'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.type_parameter_group.applicable_kinds = type_parameter
+dotnet_naming_rule.type_parameter_rule.symbols              = type_parameter_group
+dotnet_naming_rule.type_parameter_rule.style                = prefix_type_parameters_with_t_style
+dotnet_naming_rule.type_parameter_rule.severity             = warning
+
+# Function parameters use camelCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/naming-parameters
+dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
+dotnet_naming_rule.parameters_rule.symbols              = parameters_group
+dotnet_naming_rule.parameters_rule.style                = camel_case_style
+dotnet_naming_rule.parameters_rule.severity             = warning
+
+##########################################
+# License
+##########################################
+# The following applies as to the .editorconfig file ONLY, and is
+# included below for reference, per the requirements of the license
+# corresponding to this .editorconfig file.
+# See: https://github.com/RehanSaeed/EditorConfig
+#
+# MIT License
+#
+# Copyright (c) 2017-2019 Muhammad Rehan Saeed
+# Copyright (c) 2019 Henry Gabryjelski
+#
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute,
+# sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject
+# to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+##########################################

--- a/TopologyCardRegister/.editorconfig
+++ b/TopologyCardRegister/.editorconfig
@@ -153,7 +153,7 @@ csharp_style_pattern_local_over_anonymous_function = true:warning
 csharp_style_deconstructed_variable_declaration = true:warning
 csharp_style_prefer_index_operator = true:warning
 csharp_style_prefer_range_operator = true:warning
-csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = false:warning
 # "Null" checking preferences
 csharp_style_throw_expression = true:warning
 csharp_style_conditional_delegate_call = true:warning

--- a/TopologyCardRegister/.editorconfig
+++ b/TopologyCardRegister/.editorconfig
@@ -132,14 +132,14 @@ csharp_style_var_for_built_in_types = true:warning
 csharp_style_var_when_type_is_apparent = true:warning
 csharp_style_var_elsewhere = true:warning
 # Expression-bodied members
-csharp_style_expression_bodied_methods = true:warning
-csharp_style_expression_bodied_constructors = true:warning
-csharp_style_expression_bodied_operators = true:warning
-csharp_style_expression_bodied_properties = true:warning
-csharp_style_expression_bodied_indexers = true:warning
-csharp_style_expression_bodied_accessors = true:warning
+csharp_style_expression_bodied_methods = false:warning
+csharp_style_expression_bodied_constructors = false:warning
+csharp_style_expression_bodied_operators = false:warning
+csharp_style_expression_bodied_properties = false:warning
+csharp_style_expression_bodied_indexers = false:warning
+csharp_style_expression_bodied_accessors = when_on_single_line:warning
 csharp_style_expression_bodied_lambdas = true:warning
-csharp_style_expression_bodied_local_functions = true:warning
+csharp_style_expression_bodied_local_functions = false:warning
 # Pattern matching preferences
 csharp_style_pattern_matching_over_is_with_cast_check = true:warning
 csharp_style_pattern_matching_over_as_with_null_check = true:warning

--- a/TopologyCardRegister/.editorconfig
+++ b/TopologyCardRegister/.editorconfig
@@ -248,7 +248,7 @@ csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 # Namespace options
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#namespace-options
-csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_namespace_declarations = block_scoped:warning
 
 ##########################################
 # .NET Naming Rules

--- a/TopologyCardRegister/TopologyCardRegister/JsonSaver.cs
+++ b/TopologyCardRegister/TopologyCardRegister/JsonSaver.cs
@@ -1,56 +1,61 @@
-﻿using Newtonsoft.Json;
-
-public class JsonSaver
+﻿namespace TopologyCardRegister
 {
-    class TopologyCard
+    using Newtonsoft.Json;
+
+    public class JsonSaver
     {
-        public string ImageName { get; set; }
-        public int[] HoleCount { get; set; }
-    }
-
-
-    /// <summary>
-    /// 入力されたholeCountと画像名をjsonに保存します
-    /// </summary>
-    static public void SaveJson(string jsonPath, string imageName, int[] holeCount)
-    {
-        List<TopologyCard> topologyCards = new List<TopologyCard>();
-        if (File.Exists(jsonPath))
+        private class TopologyCard
         {
-            topologyCards = LoadTopologyCardJson(jsonPath);
-        }
+            public string ImageName { get; set; }
+            public int[] HoleCount { get; set; }
 
-        // 読み込んだファイルに既に同名の画像が存在する場合、holeCountを上書きする
-        topologyCards.RemoveAll(x => x.ImageName == imageName);
-
-        topologyCards.Add(new TopologyCard
-        {
-            ImageName = imageName,
-            HoleCount = holeCount,
-        });
-
-        File.WriteAllText(jsonPath, JsonConvert.SerializeObject(topologyCards));
-    }
-
-    /// <summary>
-    /// 指定されたjsonが既に存在する場合は内容を読み込みます。
-    /// </summary>
-    static List<TopologyCard> LoadTopologyCardJson(string jsonPath)
-    {
-        try
-        {
-            List<TopologyCard>? readData = JsonConvert.DeserializeObject<List<TopologyCard>>(File.ReadAllText(jsonPath));
-
-            if (readData != null)
+            public TopologyCard(string imageNamem, int[] holeCount)
             {
-                return readData;
+                this.ImageName = imageNamem;
+                this.HoleCount = holeCount;
             }
         }
-        catch (Newtonsoft.Json.JsonSerializationException)
+
+
+        /// <summary>
+        /// 入力されたholeCountと画像名をjsonに保存します
+        /// </summary>
+        public static void SaveJson(string jsonPath, string imageName, int[] holeCount)
         {
-            return new List<TopologyCard>();
+            var topologyCards = new List<TopologyCard>();
+            if (File.Exists(jsonPath))
+            {
+                topologyCards = LoadTopologyCardJson(jsonPath);
+            }
+
+            // 読み込んだファイルに既に同名の画像が存在する場合、holeCountを上書きする
+            topologyCards.RemoveAll(x => x.ImageName == imageName);
+
+            topologyCards.Add(new TopologyCard(imageName, holeCount));
+
+            File.WriteAllText(jsonPath, JsonConvert.SerializeObject(topologyCards));
         }
 
-        return new List<TopologyCard>();
+        /// <summary>
+        /// 指定されたjsonが既に存在する場合は内容を読み込みます。
+        /// </summary>
+        private static List<TopologyCard> LoadTopologyCardJson(string jsonPath)
+        {
+            try
+            {
+                var readData = JsonConvert.DeserializeObject<List<TopologyCard>>(File.ReadAllText(jsonPath));
+
+                if (readData != null)
+                {
+                    return readData;
+                }
+            }
+            catch (JsonSerializationException)
+            {
+                return new List<TopologyCard>();
+            }
+
+            return new List<TopologyCard>();
+        }
     }
 }

--- a/TopologyCardRegister/TopologyCardRegister/MainForm.cs
+++ b/TopologyCardRegister/TopologyCardRegister/MainForm.cs
@@ -2,68 +2,67 @@
 {
     public partial class MainForm : Form
     {
-        string[] m_svgFilePaths;
-        int m_nowPage;
-        int[] m_holeCount;
-
-        const int DISPLAY_IMAGE_HEIGHT_IN_PIXELS = 1024;
-        const int DISPLAY_IMAGE_WIDTH_IN_PIXELS = 1024;
-        static readonly Color DISPLAY_IMAGE_BACKGROUND_COLOR = Color.White;
+        private string[] svgFilePaths;
+        private int nowPage;
+        private int[] holeCount;
+        private const int DISPLAY_IMAGE_HEIGHT_IN_PIXELS = 1024;
+        private const int DISPLAY_IMAGE_WIDTH_IN_PIXELS = 1024;
+        private static readonly Color DISPLAY_IMAGE_BACKGROUND_COLOR = Color.White;
 
         public MainForm()
         {
-            m_svgFilePaths = Array.Empty<string>();
-            m_nowPage = 0;
-            m_holeCount = Array.Empty<int>();
+            this.svgFilePaths = Array.Empty<string>();
+            this.nowPage = 0;
+            this.holeCount = Array.Empty<int>();
 
-            InitializeComponent();
-            holeCountLabel.Text = string.Empty;
+            this.InitializeComponent();
+            this.holeCountLabel.Text = string.Empty;
         }
 
         /// <summary>
         /// svgLoadボタンが押された際の挙動を定義します
         /// </summary>
-        void OnClickLoadSvgButton(object sender, EventArgs e)
+        private void OnClickLoadSvgButton(object sender, EventArgs e)
         {
-            m_svgFilePaths = RequestSvgFilePaths();
+            this.svgFilePaths = RequestSvgFilePaths();
 
-            if (m_svgFilePaths.Length != 0)
+            if (this.svgFilePaths.Length != 0)
             {
-                m_nowPage = 0;
-                DisplaySvg(m_svgFilePaths[m_nowPage]);
-                TryTogglePaginationButton();
+                this.nowPage = 0;
+                this.DisplaySvg(this.svgFilePaths[this.nowPage]);
+                this.TryTogglePaginationButton();
             }
-            TryEnableSaveCardButton();
+            this.TryEnableSaveCardButton();
         }
 
         /// <summary>
         /// 入力された画像のパスを読み込み画面に表示します
         /// </summary>
-        void DisplaySvg(string svgFilePath)
+        private void DisplaySvg(string svgFilePath)
         {
-            Bitmap bitmap = LoadSvg(svgFilePath);
+            var bitmap = LoadSvg(svgFilePath);
 
-            svgDisplayBox.Size = bitmap.Size;
-            svgDisplayBox.Image = bitmap;
+            this.svgDisplayBox.Size = bitmap.Size;
+            this.svgDisplayBox.Image = bitmap;
 
-            DisplayHoleCount(bitmap);
+            this.DisplayHoleCount(bitmap);
         }
 
         /// <summary>
         /// 入力された画像のholeCountを画面に表示します
         /// </summary>
-        void DisplayHoleCount(Bitmap bitmap)
+        private void DisplayHoleCount(Bitmap bitmap)
         {
-            m_holeCount = TopologyStatusCalculator.CalculateHoleCount(bitmap).ToArray();
-            holeCountLabel.Text = string.Join(',', m_holeCount.Select(num => num.ToString()));
+            this.holeCount = TopologyStatusCalculator.CalculateHoleCount(bitmap).ToArray();
+            this.holeCountLabel.Text = string.Join(',', this.holeCount.Select(num => num));
         }
 
         /// <summary>
         /// svg画像のファイルパスの入力をユーザーにリクエストします。
         /// </summary>
-        string[] RequestSvgFilePaths()
+        private static string[] RequestSvgFilePaths()
         {
-            using (OpenFileDialog openFileDialog = new OpenFileDialog())
+            using (var openFileDialog = new OpenFileDialog())
             {
                 openFileDialog.Filter = "svg files (*.svg)|*.svg";
                 openFileDialog.Multiselect = true;
@@ -80,7 +79,7 @@
         /// <summary>
         /// svg画像を読み込みます
         /// </summary>
-        Bitmap LoadSvg(string filePath)
+        private static Bitmap LoadSvg(string filePath)
         {
             var svgDocument = Svg.SvgDocument.Open(filePath);
             svgDocument.Children.Insert(0, new Svg.SvgRectangle
@@ -99,77 +98,77 @@
         /// <summary>
         /// outputSvgボタンを押した際の挙動を定義します
         /// </summary>
-        void OnClickOutputSvgButton(object sender, EventArgs e)
+        private void OnClickOutputSvgButton(object sender, EventArgs e)
         {
-            using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
+            using (var folderBrowserDialog = new FolderBrowserDialog())
             {
                 if (folderBrowserDialog.ShowDialog() == DialogResult.OK)
                 {
-                    outputSvgPathTextBox.Text = folderBrowserDialog.SelectedPath;
+                    this.outputSvgPathTextBox.Text = folderBrowserDialog.SelectedPath;
                 }
             }
-            TryEnableSaveCardButton();
+            this.TryEnableSaveCardButton();
         }
 
         /// <summary>
         /// OutputHoleCountボタンを押した際の挙動を定義します
         /// </summary>
-        void OnClickOutputHoleCountbutton(object sender, EventArgs e)
+        private void OnClickOutputHoleCountbutton(object sender, EventArgs e)
         {
-            using (SaveFileDialog saveFileDialog = new SaveFileDialog())
+            using (var saveFileDialog = new SaveFileDialog())
             {
                 saveFileDialog.Filter = "json files (*.json)|*.json";
                 saveFileDialog.OverwritePrompt = false;
 
                 if (saveFileDialog.ShowDialog() == DialogResult.OK)
                 {
-                    outputHoleCountPathBox.Text = saveFileDialog.FileName;
+                    this.outputHoleCountPathBox.Text = saveFileDialog.FileName;
                 }
             }
-            TryEnableSaveCardButton();
+            this.TryEnableSaveCardButton();
         }
 
         /// <summary>
         /// saveCarボタンを押した際の挙動を定義します
         /// </summary>
-        void OnClickSaveCardButton(object sender, EventArgs e)
+        private void OnClickSaveCardButton(object sender, EventArgs e)
         {
-            string svgFileName = Path.GetFileName(m_svgFilePaths[m_nowPage]);
-            string jsonPath = outputHoleCountPathBox.Text;
-            string svgFolderPath = outputSvgPathTextBox.Text;
+            var svgFileName = Path.GetFileName(this.svgFilePaths[this.nowPage]);
+            var jsonPath = this.outputHoleCountPathBox.Text;
+            var svgFolderPath = this.outputSvgPathTextBox.Text;
 
             // 画像を保存する
-            File.Copy(m_svgFilePaths[m_nowPage], Path.Combine(svgFolderPath, svgFileName), true);
+            File.Copy(this.svgFilePaths[this.nowPage], Path.Combine(svgFolderPath, svgFileName), true);
 
             // jsonを保存する
-            JsonSaver.SaveJson(jsonPath, svgFileName, m_holeCount);
+            JsonSaver.SaveJson(jsonPath, svgFileName, this.holeCount);
         }
 
         /// <summary>
         /// 条件を満たしている場合にsaveCardボタンをアクティブにします。
         /// </summary>
-        void TryEnableSaveCardButton()
+        private void TryEnableSaveCardButton()
         {
-            if (CanSaveCard())
+            if (this.CanSaveCard())
             {
-                saveCardButton.Enabled = true;
+                this.saveCardButton.Enabled = true;
             }
         }
 
         /// <summary>
         /// 保存に必要な情報が入力されているかどうかを判定します。
         /// </summary>
-        bool CanSaveCard()
+        private bool CanSaveCard()
         {
-            if (outputSvgPathTextBox.Text == string.Empty)
+            if (this.outputSvgPathTextBox.Text == string.Empty)
             {
                 return false;
             }
-            if (outputHoleCountPathBox.Text == string.Empty)
+            if (this.outputHoleCountPathBox.Text == string.Empty)
             {
                 return false;
             }
-            if (holeCountLabel.Text == string.Empty)
+            if (this.holeCountLabel.Text == string.Empty)
             {
                 return false;
             }
@@ -180,30 +179,30 @@
         /// <summary>
         /// ページを切り替えるボタンの状態を切り替える必要がある場合は切り替えます。
         /// </summary>
-        void TryTogglePaginationButton()
+        private void TryTogglePaginationButton()
         {
-            prevButton.Enabled = m_nowPage > 0;
-            nextButton.Enabled = m_nowPage < m_svgFilePaths.Length - 1;
+            this.prevButton.Enabled = this.nowPage > 0;
+            this.nextButton.Enabled = this.nowPage < this.svgFilePaths.Length - 1;
         }
 
         /// <summary>
         /// prevButtonを押した際の挙動を定義します
         /// </summary>
-        void OnClickPrevButton(object sender, EventArgs e)
+        private void OnClickPrevButton(object sender, EventArgs e)
         {
-            m_nowPage--;
-            DisplaySvg(m_svgFilePaths[m_nowPage]);
-            TryTogglePaginationButton();
+            this.nowPage--;
+            this.DisplaySvg(this.svgFilePaths[this.nowPage]);
+            this.TryTogglePaginationButton();
         }
 
         /// <summary>
         /// nextButtonを押した際の挙動を定義します
         /// </summary>
-        void OnClickNextButton(object sender, EventArgs e)
+        private void OnClickNextButton(object sender, EventArgs e)
         {
-            m_nowPage++;
-            DisplaySvg(m_svgFilePaths[m_nowPage]);
-            TryTogglePaginationButton();
+            this.nowPage++;
+            this.DisplaySvg(this.svgFilePaths[this.nowPage]);
+            this.TryTogglePaginationButton();
         }
     }
 }

--- a/TopologyCardRegister/TopologyCardRegister/Program.cs
+++ b/TopologyCardRegister/TopologyCardRegister/Program.cs
@@ -6,7 +6,7 @@ namespace TopologyCardRegister
         ///  The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+        private static void Main()
         {
             // To customize application configuration such as set high DPI settings or default font,
             // see https://aka.ms/applicationconfiguration.


### PR DESCRIPTION
#15 
コード規則の統一のために.editorconfigを追加した
個人的に好みでIDE0160, IDE0022, IDE0090の設定を変更した(以下3点)

1. 名前空間の設定をファイルスコープからブロックスコープに変更 (IDE0160)
2. メソッドの実行式が1行のときに式本体に省略できないように変更 (IDE0022)
3. new式を簡略化できないように変更 (IDE0090)