### PR TITLE
Code Coverage Report Actionを使用してサマリーテキストを修飾した

### DIFF
--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -52,6 +52,19 @@ jobs:
         name: coverage-report
         path: ./TopologyCardRegister/TopologyCardRegister.Tests/coverage_report/
 
+    - name: Code Coverage Report
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: ./coverage.cobertura.xml
+        badge: true
+        fail_below_min: true
+        format: markdown
+        hide_branch_rate: false
+        hide_complexity: false
+        indicators: true
+        output: both
+        thresholds: '60 80'
+
     - name: Add Coverage PR Comment
       uses: marocchino/sticky-pull-request-comment@v2
       if: github.event_name == 'pull_request'

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -53,22 +53,34 @@ jobs:
         path: ./TopologyCardRegister/TopologyCardRegister.Tests/coverage_report/
 
     - name: Code Coverage Report
-      uses: irongut/CodeCoverageSummary@v1.3.0
+      uses: insightsengineering/coverage-action@v2
       with:
-        filename: ./coverage.cobertura.xml
-        badge: true
-        fail_below_min: true
-        format: markdown
-        hide_branch_rate: false
-        hide_complexity: false
-        indicators: true
-        output: both
-        thresholds: '60 80'
+        # Path to the Cobertura XML report.
+        path: ./TopologyCardRegister/TopologyCardRegister.Tests/TestResults/*/coverage.cobertura.xml
+        # Minimum total coverage, if you want to the
+        # workflow to enforce it as a standard.
+        # This has no effect if the `fail` arg is set to `false`.
+        threshold: 80
+        # Fail the workflow if the minimum code coverage
+        # reuqirements are not satisfied.
+        fail: true
+        # Publish the rendered output as a PR comment
+        publish: true
+        # Create a coverage diff report.
+        diff: true
+        # Branch to diff against.
+        # Compare the current coverage to the coverage
+        # determined on this branch.
+        diff-branch: main
+        # This is where the coverage reports for the
+        # `diff-branch` are stored.
+        # Branch is created if it doesn't already exist'.
+        diff-storage: _xml_coverage_reports
 
-    - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@v2
-      if: github.event_name == 'pull_request'
-      with:
-        recreate: true
-        path: ./TopologyCardRegister/TopologyCardRegister.Tests/coverage_report/Summary.txt
+#    - name: Add Coverage PR Comment
+#      uses: marocchino/sticky-pull-request-comment@v2
+#      if: github.event_name == 'pull_request'
+#      with:
+#        recreate: true
+#        path: ./TopologyCardRegister/TopologyCardRegister.Tests/coverage_report/Summary.txt
 

--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -77,10 +77,4 @@ jobs:
         # Branch is created if it doesn't already exist'.
         diff-storage: _xml_coverage_reports
 
-#    - name: Add Coverage PR Comment
-#      uses: marocchino/sticky-pull-request-comment@v2
-#      if: github.event_name == 'pull_request'
-#      with:
-#        recreate: true
-#        path: ./TopologyCardRegister/TopologyCardRegister.Tests/coverage_report/Summary.txt
 


### PR DESCRIPTION
Change #39 
コードカバレッジのサマリーを見やすくするために[Code Coverage Report Action](https://github.com/marketplace/actions/code-coverage-report-action#code-coverage-report-action)を使用してサマリーテキストを修飾した