### PR TITLE
ゲームリセット時にカードを裏返した際のタイマーをリセットするようにした

### DIFF
--- a/Scripts/gameController.js
+++ b/Scripts/gameController.js
@@ -100,7 +100,7 @@ var GameController = /** @class */ (function () {
                 this.selectedCards.length = 0;
             }
             else {
-                setTimeout(function () {
+                this.resetCardTimerId = setTimeout(function () {
                     _this.flipSelectedCardsToBack();
                     _this.selectedCards.length = 0;
                 }, this.flippingWaitTimeMilliseconds);
@@ -120,6 +120,7 @@ var GameController = /** @class */ (function () {
      */
     GameController.prototype.restartGame = function () {
         var _this = this;
+        clearTimeout(this.resetCardTimerId);
         var cardStatus = this.gameEngine.startGame(this.cardsOnBoard.length);
         var _loop_2 = function (i) {
             this_2.cardsOnBoard[i] = this_2.cardsOnBoard[i].cloneWithNewImage(cardStatus[i].matchingKey, this_2.getImagePath(cardStatus[i].imageName), function () { return _this.cardClickedCallback(_this.cardsOnBoard[i]); });

--- a/Scripts/gameController.ts
+++ b/Scripts/gameController.ts
@@ -10,6 +10,7 @@ export class GameController {
     private readonly maxSelectableCard: number;
     private readonly flippingWaitTimeMilliseconds: number;
     private readonly imageFolderPath: string;
+    private resetCardTimerId: NodeJS.Timeout;
 
     /**
      * GameControllerクラスのコンストラクタ
@@ -116,7 +117,7 @@ export class GameController {
             if (this.selectedCards.every((card) => Card.canMatchCard(card, this.selectedCards[0]))) {
                 this.selectedCards.length = 0;
             } else {
-                setTimeout(() => {
+                this.resetCardTimerId = setTimeout(() => {
                     this.flipSelectedCardsToBack();
                     this.selectedCards.length = 0;
                 }, this.flippingWaitTimeMilliseconds);
@@ -137,6 +138,8 @@ export class GameController {
      * ゲームを再開します
      */
     public restartGame(): void {
+        clearTimeout(this.resetCardTimerId);
+
         const cardStatus = this.gameEngine.startGame(this.cardsOnBoard.length);
 
         for (let i = 0; i < cardStatus.length; i++) {


### PR DESCRIPTION
Fix #64 
カードを裏返した際のタイマーが、restart game時にリセットされないため挙動がおかしくなっているときがあった。
これを修正するために、restart gameした際にカードを裏返したタイマーをリセットするように変更した