### PR TITLE
Refactoring window.onload#73

### DIFF
--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -9,7 +9,7 @@ const GAME_CONFIG = {
     flippingWaitTimeMilliseconds: 1000,
     maxSelectableCard: 2 // FIXME: 現状の実装では選択可能枚数が2枚の時のみ実装されている
 };
-window.onload = () => {
+export function run() {
     const gameInitializer = new GameElementInitializer(GAME_CONFIG, new CardDomFactory, new TopologyCardJsonLoader);
     gameInitializer.initialize();
-};
+}

--- a/Scripts/main.ts
+++ b/Scripts/main.ts
@@ -11,7 +11,7 @@ const GAME_CONFIG: GameConfig = {
     maxSelectableCard: 2 // FIXME: 現状の実装では選択可能枚数が2枚の時のみ実装されている
 };
 
-window.onload = () => {
+export function run() {
     const gameInitializer = new GameElementInitializer(GAME_CONFIG, new CardDomFactory, new TopologyCardJsonLoader);
     gameInitializer.initialize();
-};
+}

--- a/index.html
+++ b/index.html
@@ -7,6 +7,11 @@
     <link rel="stylesheet" type="text/css" href="styles.css">
 </head>
 
+<script type="module">
+    import { run } from './Scripts/main.js';
+    window.addEventListener('DOMContentLoaded', run);
+</script>
+
 <body>
     <h1>トポロジー神経衰弱ゲーム</h1>
     <div id="game-board">
@@ -30,7 +35,6 @@
     </div>
 
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script type="module" src="./Scripts/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Refactoring #73
mainクラスからwindow.onloadの処理を削除した。
htmlからonload()時にrunを呼び出す事ができなかったので代替手段として
window.addEventListener('DOMContentLoaded', run);
とした